### PR TITLE
Replace string literal key with selector

### DIFF
--- a/Tweak.x
+++ b/Tweak.x
@@ -1,6 +1,8 @@
 #import <UIKit/UIKit.h>
 #import "SMTPrefs/SMTUserDefaults.h"
 
+#define kTouchViewKey @selector(ShowMyTouches_TouchView)
+
 BOOL isRecording(void) {
     for (UIScreen *screen in [UIScreen screens]) {
         if ([screen isCaptured]) {
@@ -55,12 +57,12 @@ BOOL isRecording(void) {
                         [touch.window addSubview:touchView];
                     });
 
-                    objc_setAssociatedObject(touch, @"TouchView", touchView, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                    objc_setAssociatedObject(touch, kTouchViewKey, touchView, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
                 }
             }
 
             if (touch.phase == UITouchPhaseMoved) {
-                touchView = objc_getAssociatedObject(touch, @"TouchView");
+                touchView = objc_getAssociatedObject(touch, kTouchViewKey);
                 if (touchView) {
                     dispatch_async(dispatch_get_main_queue(), ^{
                         touchView.center = CGPointMake(touchPoint.x, touchPoint.y);
@@ -69,7 +71,7 @@ BOOL isRecording(void) {
             }
 
             if (touch.phase == UITouchPhaseEnded || touch.phase == UITouchPhaseCancelled) {
-                touchView = objc_getAssociatedObject(touch, @"TouchView");
+                touchView = objc_getAssociatedObject(touch, kTouchViewKey);
                 if (touchView) {
                     if (touch.tapCount > 1) {
                         [touchView removeFromSuperview];
@@ -82,7 +84,7 @@ BOOL isRecording(void) {
                             [touchView removeFromSuperview];
                         }];
                     }
-                    objc_setAssociatedObject(touch, @"TouchView", nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                    objc_setAssociatedObject(touch, kTouchViewKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
                 }
             }
         }


### PR DESCRIPTION
`objc_getAssociatedObject` and `objc_setAssociatedObject` take a `void *` as the key argument. Therefore, the pointer itself is the key, not the data it points to. This means that the pointer you use must be unique. However, string literals in Objective-C are not guaranteed to satisfy this requirement. See: [clang documentation - Objective-C Literals - Caveats](https://clang.llvm.org/docs/ObjectiveCLiterals.html#caveats)

This pull request replaces these keys with selectors, which are guaranteed to be unique by the Objective-C runtime.
